### PR TITLE
Clean up annotations from previous steps

### DIFF
--- a/.buildkite/assets/functions.sh
+++ b/.buildkite/assets/functions.sh
@@ -83,3 +83,19 @@ behind_the_scenes_annotation() {
 
   buildkite-agent annotate --priority "$PRIORITY" --style "$STYLE" --context "$CONTEXT" "$ANNOTATION_BODY"
 }
+
+clear_annotations() {
+    local OLD_ANNOTATIONS="$1"
+    if [ $OLD_ANNOTATIONS = "static" ]; then
+        buildkite-agent annotation remove --context 'ctx-error'
+        buildkite-agent annotation remove --context 'ctx-warning'
+        buildkite-agent annotation remove --context 'ctx-default'
+        buildkite-agent annotation remove --context 'ctx-info'
+        buildkite-agent annotation remove --context 'example'
+
+        buildkite-agent meta-data set "annotations" "none"
+    fi
+    if [ $OLD_ANNOTATIONS = "dynamic" ]; then
+        buildkite-agent annotation remove --context "deploy-01"
+    fi
+}

--- a/.buildkite/assets/functions.sh
+++ b/.buildkite/assets/functions.sh
@@ -97,5 +97,7 @@ clear_annotations() {
     fi
     if [ $OLD_ANNOTATIONS = "dynamic" ]; then
         buildkite-agent annotation remove --context "deploy-01"
+
+        buildkite-agent meta-data set "annotations" "none"
     fi
 }

--- a/.buildkite/demokite.sh
+++ b/.buildkite/demokite.sh
@@ -18,15 +18,15 @@ CURRENT_STATE=""
 FIRST_STEP_KEY="begin"
 CURRENT_DIR=$(pwd)
 
-OLD_ANNOTATIONS=$(buildkite-agent meta-data get "annotations")
+# OLD_ANNOTATIONS=$(buildkite-agent meta-data get "annotations")
 
-if [ $OLD_ANNOTATIONS = "static" ]; then
-  clear_annotations "$OLD_ANNOTATIONS"
-fi
+# if [ $OLD_ANNOTATIONS = "static" ]; then
+#   clear_annotations "$OLD_ANNOTATIONS"
+# fi
 
-if [ $OLD_ANNOTATIONS = "dynamic" ]; then
-  clear_annotations "$OLD_ANNOTATIONS"
-fi
+# if [ $OLD_ANNOTATIONS = "dynamic" ]; then
+#   clear_annotations "$OLD_ANNOTATIONS"
+# fi
 
 if [ "$BUILDKITE_STEP_KEY" != "$FIRST_STEP_KEY" ]; then
   CURRENT_STATE=$(buildkite-agent meta-data get "choice")
@@ -36,7 +36,6 @@ if [ "$BUILDKITE_STEP_KEY" != "$FIRST_STEP_KEY" ]; then
     pipeline_upload ".buildkite/steps/logs/logs.yml"
   fi
   if [ $CURRENT_STATE = "annotations" ]; then
-    # buildkite-agent meta-data set "annotations" "true"
     pipeline_upload ".buildkite/steps/annotations/annotations.yml"
   fi
   if [ $CURRENT_STATE = "parallel-steps" ]; then

--- a/.buildkite/demokite.sh
+++ b/.buildkite/demokite.sh
@@ -18,6 +18,16 @@ CURRENT_STATE=""
 FIRST_STEP_KEY="begin"
 CURRENT_DIR=$(pwd)
 
+OLD_ANNOTATIONS=$(buildkite-agent meta-data get "annotations")
+
+if [ $OLD_ANNOTATIONS = "static" ]; then
+  clear_annotations "$OLD_ANNOTATIONS"
+fi
+
+if [ $OLD_ANNOTATIONS = "dynamic" ]; then
+  clear_annotations "$OLD_ANNOTATIONS"
+fi
+
 if [ "$BUILDKITE_STEP_KEY" != "$FIRST_STEP_KEY" ]; then
   CURRENT_STATE=$(buildkite-agent meta-data get "choice")
   echo "BUILDKITE_STEP_KEY: $BUILDKITE_STEP_KEY"
@@ -26,6 +36,7 @@ if [ "$BUILDKITE_STEP_KEY" != "$FIRST_STEP_KEY" ]; then
     pipeline_upload ".buildkite/steps/logs/logs.yml"
   fi
   if [ $CURRENT_STATE = "annotations" ]; then
+    # buildkite-agent meta-data set "annotations" "true"
     pipeline_upload ".buildkite/steps/annotations/annotations.yml"
   fi
   if [ $CURRENT_STATE = "parallel-steps" ]; then

--- a/.buildkite/demokite.sh
+++ b/.buildkite/demokite.sh
@@ -18,17 +18,17 @@ CURRENT_STATE=""
 FIRST_STEP_KEY="begin"
 CURRENT_DIR=$(pwd)
 
-# OLD_ANNOTATIONS=$(buildkite-agent meta-data get "annotations")
-
-# if [ $OLD_ANNOTATIONS = "static" ]; then
-#   clear_annotations "$OLD_ANNOTATIONS"
-# fi
-
-# if [ $OLD_ANNOTATIONS = "dynamic" ]; then
-#   clear_annotations "$OLD_ANNOTATIONS"
-# fi
-
 if [ "$BUILDKITE_STEP_KEY" != "$FIRST_STEP_KEY" ]; then
+  OLD_ANNOTATIONS=$(buildkite-agent meta-data get "annotations")
+
+  if [ $OLD_ANNOTATIONS = "static" ]; then
+    clear_annotations "$OLD_ANNOTATIONS"
+  fi
+
+  if [ $OLD_ANNOTATIONS = "dynamic" ]; then
+    clear_annotations "$OLD_ANNOTATIONS"
+  fi
+
   CURRENT_STATE=$(buildkite-agent meta-data get "choice")
   echo "BUILDKITE_STEP_KEY: $BUILDKITE_STEP_KEY"
   echo "CHOICE: $CURRENT_STATE"
@@ -55,6 +55,7 @@ if [ "$BUILDKITE_STEP_KEY" != "$FIRST_STEP_KEY" ]; then
 
   behind_the_scenes_annotation "$CURRENT_STATE"
 else
+  buildkite-agent meta-data set "annotations" "none"
   artifact_upload ".buildkite/assets/behind-the-scenes/block-step.png"
   behind_the_scenes_annotation "$FIRST_STEP_KEY"
   pipeline_upload ".buildkite/steps/ask/ask.yml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,7 @@
 steps:
   - label: ":magic_wand: Let's Begin"
     key: "begin"
-    command: ".buildkite/demokite.sh"
+    commands:
+      - buildkite-agent meta-data set "annotations" "none"
+      - ".buildkite/demokite.sh"
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,5 @@
 steps:
   - label: ":magic_wand: Let's Begin"
     key: "begin"
-    commands:
-      - buildkite-agent meta-data set "annotations" "none"
-      - ".buildkite/demokite.sh"
+    command: ".buildkite/demokite.sh"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 steps:
   - label: ":magic_wand: Let's Begin"
     key: "begin"
-    command: buildkite-agent meta-data set "annotations" "none" && .buildkite/demokite.sh
+    command: ".buildkite/demokite.sh"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 steps:
   - label: ":magic_wand: Let's Begin"
     key: "begin"
-    command: ".buildkite/demokite.sh"
+    command: buildkite-agent meta-data set "annotations" "none" && .buildkite/demokite.sh
 

--- a/.buildkite/steps/annotations/annotations.sh
+++ b/.buildkite/steps/annotations/annotations.sh
@@ -32,6 +32,8 @@ printf '%b\n' "$(cat $FILE_PATH)" | buildkite-agent annotate --style 'success' -
 # upload assets as artifacts
 buildkite-agent artifact upload "assets/*" --log-level error;
 
+buildkite-agent meta-data set "annotations" "static"
+
 cd ../ask;
 
 pipeline_upload "ask.yml"

--- a/.buildkite/steps/deploy-progress/deploy-progress.sh
+++ b/.buildkite/steps/deploy-progress/deploy-progress.sh
@@ -290,6 +290,8 @@ buildkite-agent annotate --style "success" --context "deploy-01"
 
 ls -lah ./assets/;
 
+buildkite-agent meta-data set "annotations" "dynamic"
+
 cd ../ask;
 
 pipeline_upload "ask.yml"


### PR DESCRIPTION
Clean up old annotations so they dont hang around on next steps. Does this using a meta-data "annotations" key. 