### PR TITLE
Link directly to the job showing off logs from the behind the scenes annotation

### DIFF
--- a/.buildkite/demokite.sh
+++ b/.buildkite/demokite.sh
@@ -37,23 +37,26 @@ if [ "$BUILDKITE_STEP_KEY" != "$FIRST_STEP_KEY" ]; then
   fi
   if [ $CURRENT_STATE = "annotations" ]; then
     pipeline_upload ".buildkite/steps/annotations/annotations.yml"
+    behind_the_scenes_annotation "$CURRENT_STATE"
   fi
   if [ $CURRENT_STATE = "parallel-steps" ]; then
     pipeline_upload ".buildkite/steps/parallel-steps/parallel-steps.yml"
+    behind_the_scenes_annotation "$CURRENT_STATE"
   fi
   if [ $CURRENT_STATE = "deploy-progress" ]; then
     pipeline_upload ".buildkite/steps/deploy-progress/deploy-progress.yml"
+    behind_the_scenes_annotation "$CURRENT_STATE"
   fi
   if [ $CURRENT_STATE = "pass" ]; then
     artifact_upload ".buildkite/assets/behind-the-scenes/rebuild-button.png"
     pipeline_upload ".buildkite/steps/pass/pass.yml"
+    behind_the_scenes_annotation "$CURRENT_STATE"
   fi
   if [ $CURRENT_STATE = "fail" ]; then
     artifact_upload ".buildkite/assets/behind-the-scenes/rebuild-button.png"
     pipeline_upload ".buildkite/steps/fail/fail.yml"
+    behind_the_scenes_annotation "$CURRENT_STATE"
   fi
-
-  behind_the_scenes_annotation "$CURRENT_STATE"
 else
   buildkite-agent meta-data set "annotations" "none"
   artifact_upload ".buildkite/assets/behind-the-scenes/block-step.png"

--- a/.buildkite/steps/logs/logs.sh
+++ b/.buildkite/steps/logs/logs.sh
@@ -146,6 +146,8 @@ echokite "    CI=$CI" blue none italic
 echo ""
 echo -e "+++ :checkered_flag: $(echokite "fin" black none underline)"
 
+behind_the_scenes_annotation "logs"
+
 cd ../ask;
 
 pipeline_upload "ask.yml"

--- a/.buildkite/steps/logs/logs.sh
+++ b/.buildkite/steps/logs/logs.sh
@@ -146,10 +146,11 @@ echokite "    CI=$CI" blue none italic
 echo ""
 echo -e "+++ :checkered_flag: $(echokite "fin" black none underline)"
 
+# Back to the root directory
+cd ../../../;
 behind_the_scenes_annotation "logs"
 
-cd ../ask;
-
+cd .buildkite/steps/ask;
 pipeline_upload "ask.yml"
 
 # echo '--- This is a collapsed log group :white_check_mark:' && cat lorem-ipsum.txt


### PR DESCRIPTION
At the moment, we link to the `Process Input 🤖` step that uploaded the behind the scenes annotation. Instead, we want to link to the job showcasing job log features.

![CleanShot 2024-07-25 at 14 33 20@2x](https://github.com/user-attachments/assets/f865f742-3943-4d2e-b391-f263894e70a5)

